### PR TITLE
added option for derefering $refs before parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function gulpSwagger (filename, options) {
     throw new gutil.PluginError(PLUGIN_NAME, 'A file name is required');
   }
 
-  options = options || {};
+  options = options || { derefBeforeParsing: false };
 
   // Flag if user actually wants to use codeGen or just parse the schema and get json back.
   var useCodeGen = 'object' === typeof options.codegen;
@@ -84,7 +84,7 @@ module.exports = function gulpSwagger (filename, options) {
 
     // Load swagger main file and resolve external $refs
     parser.parse(file.history[0], {
-      dereference$Refs: false,
+      dereference$Refs: options.derefBeforeParsing,
       validateSchema: false,
       strictValidation: false
     }, function parseSchema (error, swaggerObject) {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "@material-dev/gulp-swagger",
+  "name": "gulp-swagger",
   "version": "0.0.7",
-  "homepage": "http://github.com/MaterialDev/gulp-swagger",
-  "description": "Gulp plugin that parses Swagger specs in JSON or YAML format, validates against the official Swagger 2.0 schema, dereferences all $ref pointers, including pointers to external files and generates client-side API code.  Forked from gersongoulart/gulp-swagger.",
+  "homepage": "http://github.com/gersongoulart/gulp-swagger",
+  "description": "Gulp plugin that parses Swagger specs in JSON or YAML format, validates against the official Swagger 2.0 schema, dereferences all $ref pointers, including pointers to external files and generates client-side API code.",
   "main": "./index.js",
-  "private": true,
   "dependencies": {
     "gulp-util": "*",
     "swagger-js-codegen": "1.1.3",
@@ -14,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/MaterialDev/gulp-swagger.git"
+    "url": "git://github.com/gersongoulart/gulp-swagger.git"
   },
   "keywords": [
     "gulp",
@@ -23,10 +22,10 @@
     "swagger",
     "codegen"
   ],
-  "author": "Richard Reedy",
+  "author": "Gerson Goulart <gerson.goulart@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "http://github.com/MaterialDev/gulp-swagger/issues"
+    "url": "http://github.com/gersongoulart/gulp-swagger/issues"
   },
   "engines": {
     "node": ">=0.8"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "gulp-swagger",
+  "name": "@material-dev/gulp-swagger",
   "version": "0.0.7",
-  "homepage": "http://github.com/gersongoulart/gulp-swagger",
-  "description": "Gulp plugin that parses Swagger specs in JSON or YAML format, validates against the official Swagger 2.0 schema, dereferences all $ref pointers, including pointers to external files and generates client-side API code.",
+  "homepage": "http://github.com/MaterialDev/gulp-swagger",
+  "description": "Gulp plugin that parses Swagger specs in JSON or YAML format, validates against the official Swagger 2.0 schema, dereferences all $ref pointers, including pointers to external files and generates client-side API code.  Forked from gersongoulart/gulp-swagger.",
   "main": "./index.js",
+  "private": true,
   "dependencies": {
     "gulp-util": "*",
     "swagger-js-codegen": "1.1.3",
@@ -13,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/gersongoulart/gulp-swagger.git"
+    "url": "git://github.com/MaterialDev/gulp-swagger.git"
   },
   "keywords": [
     "gulp",
@@ -22,10 +23,10 @@
     "swagger",
     "codegen"
   ],
-  "author": "Gerson Goulart <gerson.goulart@gmail.com>",
+  "author": "Richard Reedy",
   "license": "MIT",
   "bugs": {
-    "url": "http://github.com/gersongoulart/gulp-swagger/issues"
+    "url": "http://github.com/MaterialDev/gulp-swagger/issues"
   },
   "engines": {
     "node": ">=0.8"


### PR DESCRIPTION
In response to a problem that I was having where external file references were not being pulled in before the parsing.  I've added an option that preserves the original value and exposes an option that can be passed into the swagger command  to deref $ref.

https://github.com/gersongoulart/gulp-swagger/issues/1
