### PR TITLE
added option for derefering $refs before parsing; default is original…

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function gulpSwagger (filename, options) {
     throw new gutil.PluginError(PLUGIN_NAME, 'A file name is required');
   }
 
-  options = options || {};
+  options = options || { derefBeforeParsing: false };
 
   // Flag if user actually wants to use codeGen or just parse the schema and get json back.
   var useCodeGen = 'object' === typeof options.codegen;
@@ -84,7 +84,7 @@ module.exports = function gulpSwagger (filename, options) {
 
     // Load swagger main file and resolve external $refs
     parser.parse(file.history[0], {
-      dereference$Refs: false,
+      dereference$Refs: options.derefBeforeParsing,
       validateSchema: false,
       strictValidation: false
     }, function parseSchema (error, swaggerObject) {


### PR DESCRIPTION
In response to a problem that I was having where external file references were not being pulled in before the parsing. I've added an option that preserves the original value and exposes an option that can be passed into the swagger command to deref $ref.

https://github.com/gersongoulart/gulp-swagger/issues/1
