### PR TITLE
Fixing readme codegen example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ gulp.task('api', function() {
   gulp.src('./src/api/index.yaml')
     .pipe(swagger({
       filename: 'api.js',
-      type: 'angular' // type can be 'angular', 'node' or 'custom' (default).
+      codegen: {
+        type: 'angular' // type can be 'angular', 'node' or 'custom' (default).
+      }
     }))
     .pipe(gulp.dest('./api'));
 });


### PR DESCRIPTION
Fixing incorrect parameters for code generation example. Example was missing the wrapper `codegen` property.
