### PR TITLE
Added fix for circular reference error

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ gulp.task('watch', function () {
 });
 ```
 
+Hadling Circular reference object :
+
+While parsing the JSON back from the string use "circular-json" to parse the string to JSON by filling all the circular reference.
+
+var CircularJSON = require('circular-json');
+
+CircularJSON.parse(jsonString);
+
+
 Gulp-Swagger also passes the swagger schema to mustache options, both as an object (`swaggerObject`) and as a stringified JSON (`swaggerJSON`). Better even, there's also a compilation of all JSON-schemas passed to mustache options, handy if you want to carry on schema validation on the client-side. So inside your mustache template, you can do things like:
 
 ```

--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ Hadling Circular reference object :
 
 While parsing the JSON back from the string use "circular-json" to parse the string to JSON by filling all the circular reference.
 
+```js
 var CircularJSON = require('circular-json');
 
 CircularJSON.parse(jsonString);
-
+```
 
 Gulp-Swagger also passes the swagger schema to mustache options, both as an object (`swaggerObject`) and as a stringified JSON (`swaggerJSON`). Better even, there's also a compilation of all JSON-schemas passed to mustache options, handy if you want to carry on schema validation on the client-side. So inside your mustache template, you can do things like:
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var gutil = require('gulp-util');
 var swaggerParser = require('swagger-parser');
 var swaggerTools = require('swagger-tools').specs.v2; // Validate using the latest Swagger 2.x specification
 var CodeGen = require('swagger-js-codegen').CodeGen;
+var CircularJSON = require('circular-json');
 var PLUGIN_NAME = 'gulp-swagger';
 
 module.exports = function gulpSwagger (filename, options) {
@@ -204,7 +205,12 @@ module.exports = function gulpSwagger (filename, options) {
 						fileBuffer = CodeGen[codeGenFunction](codeGenSettings);
 					}
 					else {
-						fileBuffer = JSON.stringify(swaggerObject);
+						try{
+								fileBuffer = JSON.stringify(swaggerObject);
+						} catch (e) {
+							fileBuffer = CircularJSON.stringify(swaggerObject);
+						}
+
 					}
 
 					// Return processed file to gulp

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "gulp": "^3.9.1"
   },
   "dependencies": {
+    "circular-json": "^0.3.1",
     "gulp-util": "^3.0.7",
     "swagger-js-codegen": "^1.1.8",
     "swagger-parser": "^3.4.0",


### PR DESCRIPTION
Added circular-json package for fixing circular reference error.

Swagger specification allow models to have a reference to themselves, as it is not possible to stringify a json with circular reference i have added safe parser. So user who have circular reference will not face issues anymore.
